### PR TITLE
Update DateToolsSwift for Xcode 10.2 by fixing redundant public warnings

### DIFF
--- a/DateToolsSwift/DateTools/Date+Comparators.swift
+++ b/DateToolsSwift/DateTools/Date+Comparators.swift
@@ -43,7 +43,7 @@ public extension Date {
      *
      *  - returns: A TimeChunk representing the time between the dates, in natural form
      */
-    public func chunkBetween(date: Date) -> TimeChunk {
+    func chunkBetween(date: Date) -> TimeChunk {
         var compenentsBetween = Calendar.autoupdatingCurrent.dateComponents([.year, .month, .day, .hour, .minute, .second], from: self, to: date)
         return TimeChunk(seconds: compenentsBetween.second!, minutes: compenentsBetween.minute!, hours: compenentsBetween.hour!, days: compenentsBetween.day!, weeks: 0, months: compenentsBetween.month!, years: compenentsBetween.year!)
         // TimeChunk(seconds: secondDelta, minutes: minuteDelta, hours: hourDelta, days: dayDelta, weeks: 0, months: monthDelta, years: yearDelta)
@@ -56,7 +56,7 @@ public extension Date {
      *
      *  - returns: Bool representing comparison result
      */
-	public func equals(_ date: Date) -> Bool {
+	func equals(_ date: Date) -> Bool {
 		return self.compare(date) == .orderedSame
 	}
 	
@@ -68,7 +68,7 @@ public extension Date {
      *
      *  - returns: Bool representing comparison result
      */
-	public func isLater(than date: Date) -> Bool {
+	func isLater(than date: Date) -> Bool {
 		return self.compare(date) == .orderedDescending
 	}
     
@@ -80,7 +80,7 @@ public extension Date {
      *
      *  - returns: Bool representing comparison result
      */
-    public func isLaterThanOrEqual(to date: Date) -> Bool {
+    func isLaterThanOrEqual(to date: Date) -> Bool {
         return self.compare(date) == .orderedDescending || self.compare(date) == .orderedSame
     }
 	
@@ -92,7 +92,7 @@ public extension Date {
      *
      *  - returns: Bool representing comparison result
      */
-	public func isEarlier(than date: Date) -> Bool {
+	func isEarlier(than date: Date) -> Bool {
 		return self.compare(date) == .orderedAscending
 	}
     
@@ -104,7 +104,7 @@ public extension Date {
      *
      *  - returns:  Bool representing comparison result
      */
-    public func isEarlierThanOrEqual(to date: Date) -> Bool {
+    func isEarlierThanOrEqual(to date: Date) -> Bool {
         return self.compare(date) == .orderedAscending || self.compare(date) == .orderedSame
     }
     
@@ -115,7 +115,7 @@ public extension Date {
      *
      *  - returns: True if both paramter dates fall on the same day, false otherwise
      */
-    public func isSameDay(date : Date ) -> Bool {
+    func isSameDay(date : Date ) -> Bool {
         return Date.isSameDay(date: self, as: date)
     }
     
@@ -127,7 +127,7 @@ public extension Date {
      *
      *  - returns: True if both paramter dates fall on the same day, false otherwise
      */
-    public static func isSameDay(date: Date, as compareDate: Date) -> Bool {
+    static func isSameDay(date: Date, as compareDate: Date) -> Bool {
         let calendar = Calendar.autoupdatingCurrent
         var components = calendar.dateComponents([.era, .year, .month, .day], from: date)
         let dateOne = calendar.date(from: components)
@@ -154,7 +154,7 @@ public extension Date {
      *
      *  - returns: The years between receiver and provided date
      */
-    public func years(from date: Date) -> Int {
+    func years(from date: Date) -> Int {
         return years(from: date, calendar:nil)
     }
     
@@ -169,7 +169,7 @@ public extension Date {
      *
      *  - returns: The years between receiver and provided date
      */
-    public func months(from date: Date) -> Int {
+    func months(from date: Date) -> Int {
         return months(from: date, calendar:nil)
     }
     
@@ -184,7 +184,7 @@ public extension Date {
      *
      *  - returns: The weeks between receiver and provided date
      */
-    public func weeks(from date: Date) -> Int {
+    func weeks(from date: Date) -> Int {
         return weeks(from: date, calendar:nil)
     }
     
@@ -199,7 +199,7 @@ public extension Date {
      *
      *  - returns: The days between receiver and provided date
      */
-    public func days(from date: Date) -> Int {
+    func days(from date: Date) -> Int {
         return days(from: date, calendar:nil)
     }
     
@@ -213,7 +213,7 @@ public extension Date {
      *
      *  - returns: The hours between receiver and provided date
      */
-    public func hours(from date: Date) -> Int {
+    func hours(from date: Date) -> Int {
         return Int(self.timeIntervalSince(date)/Constants.SecondsInHour);
     }
     
@@ -227,7 +227,7 @@ public extension Date {
      *
      *  - returns: The minutes between receiver and provided date
      */
-    public func minutes(from date: Date) -> Int {
+    func minutes(from date: Date) -> Int {
         return Int(self.timeIntervalSince(date)/Constants.SecondsInMinute)
     }
     
@@ -241,7 +241,7 @@ public extension Date {
      *
      *  - returns: The seconds between receiver and provided date
      */
-    public func seconds(from date: Date) -> Int {
+    func seconds(from date: Date) -> Int {
         return Int(timeIntervalSince(date))
     }
     
@@ -259,7 +259,7 @@ public extension Date {
      *
      *  - returns: The years between receiver and provided date
      */
-    public func years(from date: Date, calendar: Calendar?) -> Int {
+    func years(from date: Date, calendar: Calendar?) -> Int {
         var calendarCopy = calendar
         if (calendar == nil) {
             calendarCopy = Calendar.autoupdatingCurrent
@@ -283,7 +283,7 @@ public extension Date {
      *
      *  - returns: The months between receiver and provided date
      */
-    public func months(from date: Date, calendar: Calendar?) -> Int{
+    func months(from date: Date, calendar: Calendar?) -> Int{
         var calendarCopy = calendar
         if (calendar == nil) {
             calendarCopy = Calendar.autoupdatingCurrent
@@ -307,7 +307,7 @@ public extension Date {
      *
      *  - returns: The weeks between receiver and provided date
      */
-    public func weeks(from date: Date, calendar: Calendar?) -> Int{
+    func weeks(from date: Date, calendar: Calendar?) -> Int{
         var calendarCopy = calendar
         if (calendar == nil) {
             calendarCopy = Calendar.autoupdatingCurrent
@@ -331,7 +331,7 @@ public extension Date {
      *
      *  - returns: The days between receiver and provided date
      */
-    public func days(from date: Date, calendar: Calendar?) -> Int {
+    func days(from date: Date, calendar: Calendar?) -> Int {
         var calendarCopy = calendar
         if (calendar == nil) {
             calendarCopy = Calendar.autoupdatingCurrent
@@ -351,7 +351,7 @@ public extension Date {
      *  The number of years until the receiver's date (0 if the receiver is the same or 
      *  earlier than now).
      */
-    public var yearsUntil: Int {
+    var yearsUntil: Int {
         return yearsLater(than: Date())
     }
     
@@ -359,7 +359,7 @@ public extension Date {
      *  The number of months until the receiver's date (0 if the receiver is the same or 
      *  earlier than now).
      */
-    public var monthsUntil: Int {
+    var monthsUntil: Int {
         return monthsLater(than: Date())
     }
     
@@ -367,7 +367,7 @@ public extension Date {
      *  The number of weeks until the receiver's date (0 if the receiver is the same or 
      *  earlier than now).
      */
-    public var weeksUntil: Int {
+    var weeksUntil: Int {
         return weeksLater(than: Date())
     }
     
@@ -375,7 +375,7 @@ public extension Date {
      *  The number of days until the receiver's date (0 if the receiver is the same or 
      *  earlier than now).
      */
-    public var daysUntil: Int {
+    var daysUntil: Int {
         return daysLater(than: Date())
     }
     
@@ -383,7 +383,7 @@ public extension Date {
      *  The number of hours until the receiver's date (0 if the receiver is the same or 
      *  earlier than now).
      */
-    public var hoursUntil: Int{
+    var hoursUntil: Int{
         return hoursLater(than: Date())
     }
     
@@ -391,7 +391,7 @@ public extension Date {
      *  The number of minutes until the receiver's date (0 if the receiver is the same or 
      *  earlier than now).
      */
-    public var minutesUntil: Int{
+    var minutesUntil: Int{
         return minutesLater(than: Date())
     }
     
@@ -399,7 +399,7 @@ public extension Date {
      *  The number of seconds until the receiver's date (0 if the receiver is the same or 
      *  earlier than now).
      */
-    public var secondsUntil: Int{
+    var secondsUntil: Int{
         return secondsLater(than: Date())
     }
     
@@ -410,7 +410,7 @@ public extension Date {
      *  The number of years the receiver's date is earlier than now (0 if the receiver is 
      *  the same or earlier than now).
      */
-    public var yearsAgo: Int {
+    var yearsAgo: Int {
         return yearsEarlier(than: Date())
     }
     
@@ -418,7 +418,7 @@ public extension Date {
      *  The number of months the receiver's date is earlier than now (0 if the receiver is 
      *  the same or earlier than now).
      */
-    public var monthsAgo: Int {
+    var monthsAgo: Int {
         return monthsEarlier(than: Date())
     }
     
@@ -426,7 +426,7 @@ public extension Date {
      *  The number of weeks the receiver's date is earlier than now (0 if the receiver is 
      *  the same or earlier than now).
      */
-    public var weeksAgo: Int {
+    var weeksAgo: Int {
         return weeksEarlier(than: Date())
     }
     
@@ -434,7 +434,7 @@ public extension Date {
      *  The number of days the receiver's date is earlier than now (0 if the receiver is 
      *  the same or earlier than now).
      */
-    public var daysAgo: Int {
+    var daysAgo: Int {
         return daysEarlier(than: Date())
     }
     
@@ -442,7 +442,7 @@ public extension Date {
      *  The number of hours the receiver's date is earlier than now (0 if the receiver is 
      *  the same or earlier than now).
      */
-    public var hoursAgo: Int {
+    var hoursAgo: Int {
         return hoursEarlier(than: Date())
     }
     
@@ -450,7 +450,7 @@ public extension Date {
      *  The number of minutes the receiver's date is earlier than now (0 if the receiver is 
      *  the same or earlier than now).
      */
-    public var minutesAgo: Int {
+    var minutesAgo: Int {
         return minutesEarlier(than: Date())
     }
     
@@ -458,7 +458,7 @@ public extension Date {
      *  The number of seconds the receiver's date is earlier than now (0 if the receiver is 
      *  the same or earlier than now).
      */
-    public var secondsAgo: Int{
+    var secondsAgo: Int{
         return secondsEarlier(than: Date())
     }
     
@@ -473,7 +473,7 @@ public extension Date {
      *
      *  - returns: The number of years
      */
-    public func yearsEarlier(than date: Date) -> Int {
+    func yearsEarlier(than date: Date) -> Int {
         return abs(min(years(from: date), 0))
     }
     
@@ -485,7 +485,7 @@ public extension Date {
      *
      *  - returns: The number of months
      */
-    public func monthsEarlier(than date: Date) -> Int {
+    func monthsEarlier(than date: Date) -> Int {
         return abs(min(months(from: date), 0));
     }
     
@@ -497,7 +497,7 @@ public extension Date {
      *
      *  - returns: The number of weeks
      */
-    public func weeksEarlier(than date: Date) -> Int {
+    func weeksEarlier(than date: Date) -> Int {
         return abs(min(weeks(from: date), 0))
     }
     
@@ -509,7 +509,7 @@ public extension Date {
      *
      *  - returns: The number of days
      */
-    public func daysEarlier(than date: Date) -> Int {
+    func daysEarlier(than date: Date) -> Int {
         return abs(min(days(from: date), 0))
     }
     
@@ -521,7 +521,7 @@ public extension Date {
      *
      *  - returns: The number of hours
      */
-    public func hoursEarlier(than date: Date) -> Int {
+    func hoursEarlier(than date: Date) -> Int {
         return abs(min(hours(from: date), 0))
     }
     
@@ -533,7 +533,7 @@ public extension Date {
      *
      *  - returns: The number of minutes
      */
-    public func minutesEarlier(than date: Date) -> Int {
+    func minutesEarlier(than date: Date) -> Int {
         return abs(min(minutes(from: date), 0))
     }
     
@@ -545,7 +545,7 @@ public extension Date {
      *
      *  - returns: The number of seconds
      */
-    public func secondsEarlier(than date: Date) -> Int {
+    func secondsEarlier(than date: Date) -> Int {
         return abs(min(seconds(from: date), 0))
     }
     
@@ -561,7 +561,7 @@ public extension Date {
      *
      *  - returns: The number of years
      */
-    public func yearsLater(than date: Date) -> Int {
+    func yearsLater(than date: Date) -> Int {
         return max(years(from: date), 0)
     }
     
@@ -574,7 +574,7 @@ public extension Date {
      *
      *  - returns: The number of months
      */
-    public func monthsLater(than date: Date) -> Int {
+    func monthsLater(than date: Date) -> Int {
         return max(months(from: date), 0)
     }
     
@@ -587,7 +587,7 @@ public extension Date {
      *
      *  - returns: The number of weeks
      */
-    public func weeksLater(than date: Date) -> Int {
+    func weeksLater(than date: Date) -> Int {
         return max(weeks(from: date), 0)
     }
     
@@ -600,7 +600,7 @@ public extension Date {
      *
      *  - returns: The number of days
      */
-    public func daysLater(than date: Date) -> Int {
+    func daysLater(than date: Date) -> Int {
         return max(days(from: date), 0)
     }
     
@@ -613,7 +613,7 @@ public extension Date {
      *
      *  - returns: The number of hours
      */
-    public func hoursLater(than date: Date) -> Int {
+    func hoursLater(than date: Date) -> Int {
         return max(hours(from: date), 0)
     }
     
@@ -626,7 +626,7 @@ public extension Date {
      *
      *  - returns: The number of minutes
      */
-    public func minutesLater(than date: Date) -> Int {
+    func minutesLater(than date: Date) -> Int {
         return max(minutes(from: date), 0)
     }
     
@@ -639,7 +639,7 @@ public extension Date {
      *
      *  - returns: The number of seconds
      */
-    public func secondsLater(than date: Date) -> Int {
+    func secondsLater(than date: Date) -> Int {
         return max(seconds(from: date), 0)
     }
 }

--- a/DateToolsSwift/DateTools/Date+Components.swift
+++ b/DateToolsSwift/DateTools/Date+Components.swift
@@ -23,7 +23,7 @@ public extension Date {
      *  - returns: The value of the component
      *
      */
-    public func component(_ component: Calendar.Component) -> Int {
+    func component(_ component: Calendar.Component) -> Int {
 		let calendar = Calendar.autoupdatingCurrent
 		return calendar.component(component, from: self)
 	}
@@ -37,7 +37,7 @@ public extension Date {
      *  - returns: The ordinal number of a smaller calendar component within a specified larger calendar component
      *
      */
-	public func ordinality(of smaller: Calendar.Component, in larger: Calendar.Component) -> Int? {
+	func ordinality(of smaller: Calendar.Component, in larger: Calendar.Component) -> Int? {
 		let calendar = Calendar.autoupdatingCurrent
 		return calendar.ordinality(of: smaller, in: larger, for: self)
 	}
@@ -54,7 +54,7 @@ public extension Date {
      *  - returns: The number of smaller units required to equal in 1 larger unit, given the date called on
      *
      */
-	public func unit(of smaller: Calendar.Component, in larger: Calendar.Component) -> Int? {
+	func unit(of smaller: Calendar.Component, in larger: Calendar.Component) -> Int? {
 		let calendar = Calendar.autoupdatingCurrent
         var units = 1
         var unitRange: Range<Int>?
@@ -125,105 +125,105 @@ public extension Date {
     /**
      *  Convenience getter for the date's `era` component
      */
-	public var era: Int {
+	var era: Int {
 		return component(.era)
 	}
 	
     /**
      *  Convenience getter for the date's `year` component
      */
-	public var year: Int {
+	var year: Int {
 		return component(.year)
 	}
 	
     /**
      *  Convenience getter for the date's `month` component
      */
-	public var month: Int {
+	var month: Int {
 		return component(.month)
 	}
 	
     /**
      *  Convenience getter for the date's `week` component
      */
-	public var week: Int {
+	var week: Int {
 		return component(.weekday)
 	}
 	
     /**
      *  Convenience getter for the date's `day` component
      */
-	public var day: Int {
+	var day: Int {
 		return component(.day)
 	}
 	
     /**
      *  Convenience getter for the date's `hour` component
      */
-	public var hour: Int {
+	var hour: Int {
 		return component(.hour)
 	}
 	
     /**
      *  Convenience getter for the date's `minute` component
      */
-	public var minute: Int {
+	var minute: Int {
 		return component(.minute)
 	}
 	
     /**
      *  Convenience getter for the date's `second` component
      */
-	public var second: Int {
+	var second: Int {
 		return component(.second)
 	}
 	
     /**
      *  Convenience getter for the date's `weekday` component
      */
-	public var weekday: Int {
+	var weekday: Int {
 		return component(.weekday)
 	}
 	
     /**
      *  Convenience getter for the date's `weekdayOrdinal` component
      */
-	public var weekdayOrdinal: Int {
+	var weekdayOrdinal: Int {
 		return component(.weekdayOrdinal)
 	}
 	
     /**
      *  Convenience getter for the date's `quarter` component
      */
-	public var quarter: Int {
+	var quarter: Int {
 		return component(.quarter)
 	}
 	
     /**
      *  Convenience getter for the date's `weekOfYear` component
      */
-	public var weekOfMonth: Int {
+	var weekOfMonth: Int {
 		return component(.weekOfMonth)
 	}
 	
     /**
      *  Convenience getter for the date's `weekOfYear` component
      */
-	public var weekOfYear: Int {
+	var weekOfYear: Int {
 		return component(.weekOfYear)
 	}
 	
     /**
      *  Convenience getter for the date's `yearForWeekOfYear` component
      */
-	public var yearForWeekOfYear: Int {
+	var yearForWeekOfYear: Int {
 		return component(.yearForWeekOfYear)
 	}
     
     /**
      *  Convenience getter for the date's `daysInMonth` component
      */
-    public var daysInMonth: Int {
+    var daysInMonth: Int {
         let calendar = Calendar.autoupdatingCurrent
         let days = calendar.range(of: .day, in: .month, for: self)
         return days!.count
@@ -234,42 +234,42 @@ public extension Date {
     /**
      *  Convenience setter for the date's `year` component
      */
-    public mutating func year(_ year: Int) {
+    mutating func year(_ year: Int) {
         self = Date.init(year: year, month: self.month, day: self.day, hour: self.hour, minute: self.minute, second: self.second)
     }
     
     /**
      *  Convenience setter for the date's `month` component
      */
-    public mutating func month(_ month: Int) {
+    mutating func month(_ month: Int) {
         self = Date.init(year: self.year, month: month, day: self.day, hour: self.hour, minute: self.minute, second: self.second)
     }
     
     /**
      *  Convenience setter for the date's `day` component
      */
-    public mutating func day(_ day: Int) {
+    mutating func day(_ day: Int) {
         self = Date.init(year: self.year, month: self.month, day: day, hour: self.hour, minute: self.minute, second: self.second)
     }
     
     /**
      *  Convenience setter for the date's `hour` component
      */
-    public mutating func hour(_ hour: Int) {
+    mutating func hour(_ hour: Int) {
         self = Date.init(year: self.year, month: self.month, day: self.day, hour: hour, minute: self.minute, second: self.second)
     }
     
     /**
      *  Convenience setter for the date's `minute` component
      */
-    public mutating func minute(_ minute: Int) {
+    mutating func minute(_ minute: Int) {
         self = Date.init(year: self.year, month: self.month, day: self.day, hour: self.hour, minute: minute, second: self.second)
     }
     
     /**
      *  Convenience setter for the date's `second` component
      */
-    public mutating func second(_ second: Int) {
+    mutating func second(_ second: Int) {
         self = Date.init(year: self.year, month: self.month, day: self.day, hour: self.hour, minute: self.minute, second: second)
     }
     
@@ -279,7 +279,7 @@ public extension Date {
     /**
      *  Determine if date is in a leap year
      */
-	public var isInLeapYear: Bool {
+	var isInLeapYear: Bool {
 		let yearComponent = component(.year)
 		
 		if yearComponent % 400 == 0 {
@@ -297,7 +297,7 @@ public extension Date {
     /**
      *  Determine if date is within the current day
      */
-	public var isToday: Bool {
+	var isToday: Bool {
 		let calendar = Calendar.autoupdatingCurrent
 		return calendar.isDateInToday(self)
 	}
@@ -305,7 +305,7 @@ public extension Date {
     /**
      *  Determine if date is within the day tomorrow
      */
-	public var isTomorrow: Bool {
+	var isTomorrow: Bool {
 		let calendar = Calendar.autoupdatingCurrent
         return calendar.isDateInTomorrow(self)
 	}
@@ -313,7 +313,7 @@ public extension Date {
     /**
      *  Determine if date is within yesterday
      */
-	public var isYesterday: Bool {
+	var isYesterday: Bool {
 		let calendar = Calendar.autoupdatingCurrent
         return calendar.isDateInYesterday(self)
 	}
@@ -321,7 +321,7 @@ public extension Date {
     /**
      *  Determine if date is in a weekend
      */
-	public var isWeekend: Bool {
+	var isWeekend: Bool {
 		if weekday == 7 || weekday == 1 {
 			return true
 		}

--- a/DateToolsSwift/DateTools/Date+Format.swift
+++ b/DateToolsSwift/DateTools/Date+Format.swift
@@ -24,7 +24,7 @@ public extension Date {
      *
      *  - returns: Represenation of the date (self) in the specified format
      */
-    public func format(with dateStyle: DateFormatter.Style, timeZone: TimeZone, locale: Locale) -> String {
+    func format(with dateStyle: DateFormatter.Style, timeZone: TimeZone, locale: Locale) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = dateStyle
         dateFormatter.timeZone = timeZone
@@ -41,7 +41,7 @@ public extension Date {
      *
      *  - returns String? - Represenation of the date (self) in the specified format
      */
-    public func format(with dateStyle: DateFormatter.Style, timeZone: TimeZone) -> String {
+    func format(with dateStyle: DateFormatter.Style, timeZone: TimeZone) -> String {
         #if os(Linux)
             return format(with: dateStyle, timeZone: timeZone, locale: Locale.current)
         #else
@@ -58,7 +58,7 @@ public extension Date {
      *
      *  - returns: Represenation of the date (self) in the specified format
      */
-    public func format(with dateStyle: DateFormatter.Style, locale: Locale) -> String {
+    func format(with dateStyle: DateFormatter.Style, locale: Locale) -> String {
         return format(with: dateStyle, timeZone: TimeZone.autoupdatingCurrent, locale: locale)
     }
     
@@ -70,7 +70,7 @@ public extension Date {
      *
      *  - returns: Represenation of the date (self) in the specified format
      */
-    public func format(with dateStyle: DateFormatter.Style) -> String {
+    func format(with dateStyle: DateFormatter.Style) -> String {
         #if os(Linux)
             return format(with: dateStyle, timeZone: TimeZone.autoupdatingCurrent, locale: Locale.current)
         #else
@@ -90,7 +90,7 @@ public extension Date {
      *
      *  - returns: Represenation of the date (self) in the specified format
      */
-    public func format(with dateFormat: String, timeZone: TimeZone, locale: Locale) -> String {
+    func format(with dateFormat: String, timeZone: TimeZone, locale: Locale) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = dateFormat
         dateFormatter.timeZone = timeZone
@@ -108,7 +108,7 @@ public extension Date {
      *
      *  - returns: Representation of the date (self) in the specified format
      */
-    public func format(with dateFormat: String, timeZone: TimeZone) -> String {
+    func format(with dateFormat: String, timeZone: TimeZone) -> String {
         #if os(Linux)
             return format(with: dateFormat, timeZone: timeZone, locale: Locale.current)
         #else
@@ -125,7 +125,7 @@ public extension Date {
      *
      *  - returns: Represenation of the date (self) in the specified format
      */
-    public func format(with dateFormat: String, locale: Locale) -> String {
+    func format(with dateFormat: String, locale: Locale) -> String {
         return format(with: dateFormat, timeZone: TimeZone.autoupdatingCurrent, locale: locale)
     }
     
@@ -137,7 +137,7 @@ public extension Date {
      *
      *  - returns: Represenation of the date (self) in the specified format
      */
-    public func format(with dateFormat: String) -> String {
+    func format(with dateFormat: String) -> String {
         #if os(Linux)
             return format(with: dateFormat, timeZone: TimeZone.autoupdatingCurrent, locale: Locale.current)
         #else

--- a/DateToolsSwift/DateTools/Date+Inits.swift
+++ b/DateToolsSwift/DateTools/Date+Inits.swift
@@ -27,7 +27,7 @@ public extension Date {
      *  - parameter minute: Minute component of new date
      *  - parameter second: Second component of new date
      */
-	public init(year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int) {
+	init(year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int) {
 		var dateComponents = DateComponents()
 		dateComponents.year = year
 		dateComponents.month = month
@@ -50,7 +50,7 @@ public extension Date {
      *  - parameter month: Month component of new date
      *  - parameter day: Day component of new date
      */
-	public init(year: Int, month: Int, day: Int) {
+	init(year: Int, month: Int, day: Int) {
 		self.init(year: year, month: month, day: day, hour: 0, minute: 0, second: 0)
 	}
 	
@@ -61,7 +61,7 @@ public extension Date {
      *  - parameter format: Format style using Apple's date formatting guide
      *  - parameter timeZone: Time zone of date
      */
-	public init(dateString: String, format: String, timeZone: TimeZone) {
+	init(dateString: String, format: String, timeZone: TimeZone) {
 		let dateFormatter = DateFormatter()
 		dateFormatter.dateStyle = .none;
 		dateFormatter.timeStyle = .none;
@@ -82,7 +82,7 @@ public extension Date {
      *  - parameter dateString: Date in the formatting given by the format parameter
      *  - parameter format: Format style using Apple's date formatting guide
      */
-	public init (dateString: String, format: String) {
+	init (dateString: String, format: String) {
 		self.init(dateString: dateString, format: format, timeZone: TimeZone.autoupdatingCurrent)
 	}	
 }

--- a/DateToolsSwift/DateTools/Date+Manipulations.swift
+++ b/DateToolsSwift/DateTools/Date+Manipulations.swift
@@ -23,7 +23,7 @@ public extension Date {
      *  - returns: A date retaining the value of the given component and all larger components,
      *  with all smaller components set to their minimum
      */
-    public func start(of component: Component) -> Date {
+    func start(of component: Component) -> Date {
         var newDate = self;
         if component == .second {
             newDate.second(self.second)
@@ -60,7 +60,7 @@ public extension Date {
      *  - returns: A date retaining the value of the given component and all larger components,
      *  with all smaller components set to their maximum
      */
-    public func end(of component: Component) -> Date {
+    func end(of component: Component) -> Date {
         var newDate = self;
         if component == .second {
             newDate.second(newDate.second + 1)
@@ -96,7 +96,7 @@ public extension Date {
         return newDate
     }
     
-    public func daysInMonth(date: Date) -> Int {
+    func daysInMonth(date: Date) -> Int {
         let month = date.month
         if month == 1 || month == 3 || month == 5 || month == 7 || month == 8 || month == 10 || month == 12 {
             // 31 day month
@@ -125,7 +125,7 @@ public extension Date {
      *  - returns: A date with components increased by the values of the
      *  corresponding `TimeChunk` variables
      */
-    public func add(_ chunk: TimeChunk) -> Date {
+    func add(_ chunk: TimeChunk) -> Date {
         let calendar = Calendar.autoupdatingCurrent
         var components = DateComponents()
         components.year = chunk.years
@@ -146,7 +146,7 @@ public extension Date {
      *  - returns: A date with components decreased by the values of the
      *  corresponding `TimeChunk` variables
      */
-    public func subtract(_ chunk: TimeChunk) -> Date {
+    func subtract(_ chunk: TimeChunk) -> Date {
         let calendar = Calendar.autoupdatingCurrent
         var components = DateComponents()
         components.year = -chunk.years
@@ -164,28 +164,28 @@ public extension Date {
     /**
      *  Operator overload for adding a `TimeChunk` to a date.
      */
-    public static func +(leftAddend: Date, rightAddend: TimeChunk) -> Date {
+    static func +(leftAddend: Date, rightAddend: TimeChunk) -> Date {
         return leftAddend.add(rightAddend)
     }
     
     /**
      *  Operator overload for subtracting a `TimeChunk` from a date.
      */
-    public static func -(minuend: Date, subtrahend: TimeChunk) -> Date {
+    static func -(minuend: Date, subtrahend: TimeChunk) -> Date {
         return minuend.subtract(subtrahend)
     }
     
     /**
      *  Operator overload for adding a `TimeInterval` to a date.
      */
-    public static func +(leftAddend: Date, rightAddend: Int) -> Date {
+    static func +(leftAddend: Date, rightAddend: Int) -> Date {
         return leftAddend.addingTimeInterval((TimeInterval(rightAddend)))
     }
     
     /**
      *  Operator overload for subtracting a `TimeInterval` from a date.
      */
-    public static func -(minuend: Date, subtrahend: Int) -> Date {
+    static func -(minuend: Date, subtrahend: Int) -> Date {
         return minuend.addingTimeInterval(-(TimeInterval(subtrahend)))
     }
     

--- a/DateToolsSwift/DateTools/Date+TimeAgo.swift
+++ b/DateToolsSwift/DateTools/Date+TimeAgo.swift
@@ -24,7 +24,7 @@ public extension Date {
      *
      *  - returns String - Formatted return string
      */
-    public static func timeAgo(since date:Date) -> String{
+    static func timeAgo(since date:Date) -> String{
         return date.timeAgo(since: Date(), numericDates: false, numericTimes: false)
     }
     
@@ -36,7 +36,7 @@ public extension Date {
      *
      *  - returns String - Formatted return string
      */
-    public static func shortTimeAgo(since date:Date) -> String {
+    static func shortTimeAgo(since date:Date) -> String {
         return date.shortTimeAgo(since:Date())
     }
     
@@ -46,7 +46,7 @@ public extension Date {
      *
      *  - returns String - Formatted return string
      */
-    public var timeAgoSinceNow: String {
+    var timeAgoSinceNow: String {
         return self.timeAgo(since:Date())
     }
     
@@ -56,11 +56,11 @@ public extension Date {
      *
      *  - returns String - Formatted return string
      */
-    public var shortTimeAgoSinceNow: String {
+    var shortTimeAgoSinceNow: String {
         return self.shortTimeAgo(since:Date())
     }
     
-    public func timeAgo(since date:Date, numericDates: Bool = false, numericTimes: Bool = false) -> String {
+    func timeAgo(since date:Date, numericDates: Bool = false, numericTimes: Bool = false) -> String {
         let calendar = NSCalendar.current
         let unitFlags = Set<Calendar.Component>([.second,.minute,.hour,.day,.weekOfYear,.month,.year])
         let earliest = self.earlierDate(date)
@@ -155,7 +155,7 @@ public extension Date {
     }
     
     
-    public func shortTimeAgo(since date:Date) -> String {
+    func shortTimeAgo(since date:Date) -> String {
         let calendar = NSCalendar.current
         let unitFlags = Set<Calendar.Component>([.second,.minute,.hour,.day,.weekOfYear,.month,.year])
         let earliest = self.earlierDate(date)
@@ -257,7 +257,7 @@ public extension Date {
      *
      *  - returns: The date that is earlier
      */
-    public func earlierDate(_ date:Date) -> Date{
+    func earlierDate(_ date:Date) -> Date{
         return (self.timeIntervalSince1970 <= date.timeIntervalSince1970) ? self : date
     }
     
@@ -268,7 +268,7 @@ public extension Date {
      *
      *  - returns: The date that is later
      */
-    public func laterDate(_ date:Date) -> Date{
+    func laterDate(_ date:Date) -> Date{
         return (self.timeIntervalSince1970 >= date.timeIntervalSince1970) ? self : date
     }
     

--- a/DateToolsSwift/DateTools/Integer+DateTools.swift
+++ b/DateToolsSwift/DateTools/Integer+DateTools.swift
@@ -15,49 +15,49 @@ public extension Int {
     /**
      *  A `TimeChunk` with its seconds component set to the value of self
      */
-    public var seconds: TimeChunk {
+    var seconds: TimeChunk {
         return TimeChunk(seconds: self, minutes: 0, hours: 0, days: 0, weeks: 0, months: 0, years: 0)
     }
     
     /**
      *  A `TimeChunk` with its minutes component set to the value of self
      */
-    public var minutes: TimeChunk {
+    var minutes: TimeChunk {
         return TimeChunk(seconds: 0, minutes: self, hours: 0, days: 0, weeks: 0, months: 0, years: 0)
     }
     
     /**
      *  A `TimeChunk` with its hours component set to the value of self
      */
-    public var hours: TimeChunk {
+    var hours: TimeChunk {
         return TimeChunk(seconds: 0, minutes: 0, hours: self, days: 0, weeks: 0, months: 0, years: 0)
     }
     
     /**
      *  A `TimeChunk` with its days component set to the value of self
      */
-    public var days: TimeChunk {
+    var days: TimeChunk {
         return TimeChunk(seconds: 0, minutes: 0, hours: 0, days: self, weeks: 0, months: 0, years: 0)
     }
     
     /**
      *  A `TimeChunk` with its weeks component set to the value of self
      */
-    public var weeks: TimeChunk {
+    var weeks: TimeChunk {
         return TimeChunk(seconds: 0, minutes: 0, hours: 0, days: 0, weeks: self, months: 0, years: 0)
     }
     
     /**
      *  A `TimeChunk` with its months component set to the value of self
      */
-    public var months: TimeChunk {
+    var months: TimeChunk {
         return TimeChunk(seconds: 0, minutes: 0, hours: 0, days: 0, weeks: 0, months: self, years: 0)
     }
     
     /**
      *  A `TimeChunk` with its years component set to the value of self
      */
-    public var years: TimeChunk {
+    var years: TimeChunk {
         return TimeChunk(seconds: 0, minutes: 0, hours: 0, days: 0, weeks: 0, months: 0, years: self)
     }
 }

--- a/DateToolsSwift/DateTools/TimePeriod.swift
+++ b/DateToolsSwift/DateTools/TimePeriod.swift
@@ -40,7 +40,7 @@ public extension TimePeriodProtocol {
     /**
      *  True if the `TimePeriod`'s duration is zero
      */
-    public var isMoment: Bool {
+    var isMoment: Bool {
         return self.beginning == self.end
     }
     
@@ -48,7 +48,7 @@ public extension TimePeriodProtocol {
      *  The duration of the `TimePeriod` in years.
      *  Returns the max int if beginning or end are nil.
      */
-    public var years: Int {
+    var years: Int {
         if self.beginning != nil && self.end != nil {
             return self.beginning!.yearsEarlier(than: self.end!)
         }
@@ -59,7 +59,7 @@ public extension TimePeriodProtocol {
      *  The duration of the `TimePeriod` in weeks.
      *  Returns the max int if beginning or end are nil.
      */
-    public var weeks: Int {
+    var weeks: Int {
         if self.beginning != nil && self.end != nil {
             return self.beginning!.weeksEarlier(than: self.end!)
         }
@@ -70,7 +70,7 @@ public extension TimePeriodProtocol {
      *  The duration of the `TimePeriod` in days.
      *  Returns the max int if beginning or end are nil.
      */
-    public var days: Int {
+    var days: Int {
         if self.beginning != nil && self.end != nil {
             return self.beginning!.daysEarlier(than: self.end!)
         }
@@ -81,7 +81,7 @@ public extension TimePeriodProtocol {
      *  The duration of the `TimePeriod` in hours.
      *  Returns the max int if beginning or end are nil.
      */
-    public var hours: Int {
+    var hours: Int {
         if self.beginning != nil && self.end != nil {
             return self.beginning!.hoursEarlier(than: self.end!)
         }
@@ -92,7 +92,7 @@ public extension TimePeriodProtocol {
      *  The duration of the `TimePeriod` in minutes.
      *  Returns the max int if beginning or end are nil.
      */
-    public var minutes: Int {
+    var minutes: Int {
         if self.beginning != nil && self.end != nil {
             return self.beginning!.minutesEarlier(than: self.end!)
         }
@@ -103,7 +103,7 @@ public extension TimePeriodProtocol {
      *  The duration of the `TimePeriod` in seconds.
      *  Returns the max int if beginning or end are nil.
      */
-    public var seconds: Int {
+    var seconds: Int {
         if self.beginning != nil && self.end != nil {
             return self.beginning!.secondsEarlier(than: self.end!)
         }
@@ -114,7 +114,7 @@ public extension TimePeriodProtocol {
      *  The duration of the `TimePeriod` in a time chunk.
      *  Returns a time chunk with all zeroes if beginning or end are nil.
      */
-    public var chunk: TimeChunk {
+    var chunk: TimeChunk {
         if beginning != nil && end != nil {
             return beginning!.chunkBetween(date: end!)
         }
@@ -125,7 +125,7 @@ public extension TimePeriodProtocol {
      *  The length of time between the beginning and end dates of the
      * `TimePeriod` as a `TimeInterval`.
      */
-    public var duration: TimeInterval {
+    var duration: TimeInterval {
         if self.beginning != nil && self.end != nil {
             return abs(self.beginning!.timeIntervalSince(self.end!))
         }
@@ -146,7 +146,7 @@ public extension TimePeriodProtocol {
      *  
      * - returns: The relationship between self and the given time period
      */
-    public func relation(to period: TimePeriodProtocol) -> Relation {
+    func relation(to period: TimePeriodProtocol) -> Relation {
         //Make sure that all start and end points exist for comparison
         if (self.beginning != nil && self.end != nil && period.beginning != nil && period.end != nil) {
             //Make sure time periods are of positive durations
@@ -206,7 +206,7 @@ public extension TimePeriodProtocol {
      *
      * - returns: True if the periods are the same
      */
-    public func equals(_ period: TimePeriodProtocol) -> Bool {
+    func equals(_ period: TimePeriodProtocol) -> Bool {
         return self.beginning == period.beginning && self.end == period.end
     }
     
@@ -218,7 +218,7 @@ public extension TimePeriodProtocol {
      *
      * - returns: True if self is inside of the given `TimePeriod`
      */
-    public func isInside(of period: TimePeriodProtocol) -> Bool {
+    func isInside(of period: TimePeriodProtocol) -> Bool {
         return period.beginning!.isEarlierThanOrEqual(to: self.beginning!) && period.end!.isLaterThanOrEqual(to: self.end!)
     }
     
@@ -230,7 +230,7 @@ public extension TimePeriodProtocol {
      *
      * - returns: True if the given `TimePeriod` is inside of self
      */
-    public func contains(_ date: Date, interval: Interval) -> Bool {
+    func contains(_ date: Date, interval: Interval) -> Bool {
         if (interval == .open) {
             return self.beginning!.isEarlier(than: date) && self.end!.isLater(than: date)
         }
@@ -249,7 +249,7 @@ public extension TimePeriodProtocol {
      *
      * - returns: True if the given `TimePeriod` is inside of self
      */
-    public func contains(_ period: TimePeriodProtocol) -> Bool {
+    func contains(_ period: TimePeriodProtocol) -> Bool {
         return self.beginning!.isEarlierThanOrEqual(to: period.beginning!) && self.end!.isLaterThanOrEqual(to: period.end!)
     }
     
@@ -260,7 +260,7 @@ public extension TimePeriodProtocol {
      *
      * - returns: True if there is a period of time that is shared by both `TimePeriod`s
      */
-    public func overlaps(with period: TimePeriodProtocol) -> Bool {
+    func overlaps(with period: TimePeriodProtocol) -> Bool {
         //Outside -> Inside
         if (period.beginning!.isEarlier(than: self.beginning!) && period.end!.isLater(than: self.beginning!)) {
             return true
@@ -283,7 +283,7 @@ public extension TimePeriodProtocol {
      *
      * - returns: True if there is a period of time or moment that is shared by both `TimePeriod`s
      */
-    public func intersects(with period: TimePeriodProtocol) -> Bool {
+    func intersects(with period: TimePeriodProtocol) -> Bool {
         return self.relation(to: period) != .after && self.relation(to: period) != .before
     }
     
@@ -294,7 +294,7 @@ public extension TimePeriodProtocol {
      *
      * - returns: True if there is a period of time between self and the given `TimePeriod` not contained by either period
      */
-    public func hasGap(between period: TimePeriodProtocol) -> Bool {
+    func hasGap(between period: TimePeriodProtocol) -> Bool {
         return self.isBefore(period: period) || self.isAfter(period: period)
     }
     
@@ -305,7 +305,7 @@ public extension TimePeriodProtocol {
      *
      * - returns: The gap between the periods. Zero if there is no gap.
      */
-    public func gap(between period: TimePeriodProtocol) -> TimeInterval {
+    func gap(between period: TimePeriodProtocol) -> TimeInterval {
         if (self.end!.isEarlier(than: period.beginning!)) {
             return abs(self.end!.timeIntervalSince(period.beginning!));
         }
@@ -323,7 +323,7 @@ public extension TimePeriodProtocol {
      *
      * - returns: The gap between the periods, zero if there is no gap
      */
-    public func gap(between period: TimePeriodProtocol) -> TimeChunk? {
+    func gap(between period: TimePeriodProtocol) -> TimeChunk? {
         if self.end != nil && period.beginning != nil {
             return (self.end?.chunkBetween(date: period.beginning!))!
         }
@@ -337,7 +337,7 @@ public extension TimePeriodProtocol {
      *
      * - returns: True if self is after the given `TimePeriod`
      */
-    public func isAfter(period: TimePeriodProtocol) -> Bool {
+    func isAfter(period: TimePeriodProtocol) -> Bool {
         return self.relation(to: period) == .after
     }
     
@@ -348,7 +348,7 @@ public extension TimePeriodProtocol {
      *
      * - returns: True if self is after the given `TimePeriod`
      */
-    public func isBefore(period: TimePeriodProtocol) -> Bool {
+    func isBefore(period: TimePeriodProtocol) -> Bool {
         return self.relation(to: period) == .before
     }
     
@@ -361,7 +361,7 @@ public extension TimePeriodProtocol {
      *
      * - parameter timeInterval: The time interval to shift the period by
      */
-    public mutating func shift(by timeInterval: TimeInterval) {
+    mutating func shift(by timeInterval: TimeInterval) {
         self.beginning?.addTimeInterval(timeInterval)
         self.end?.addTimeInterval(timeInterval)
     }
@@ -371,7 +371,7 @@ public extension TimePeriodProtocol {
      *
      * - parameter chunk: The time chunk to shift the period by
      */
-    public mutating func shift(by chunk: TimeChunk) {
+    mutating func shift(by chunk: TimeChunk) {
         self.beginning = self.beginning?.add(chunk)
         self.end = self.end?.add(chunk)
     }
@@ -387,7 +387,7 @@ public extension TimePeriodProtocol {
      * - parameter timeInterval: The time interval to lengthen the period by
      * - parameter anchor: The anchor point from which to make the change
      */
-    public mutating func lengthen(by timeInterval: TimeInterval, at anchor: Anchor) {
+    mutating func lengthen(by timeInterval: TimeInterval, at anchor: Anchor) {
         switch anchor {
         case .beginning:
             self.end = self.end?.addingTimeInterval(timeInterval)
@@ -408,7 +408,7 @@ public extension TimePeriodProtocol {
      * - parameter chunk: The time chunk to lengthen the period by
      * - parameter anchor: The anchor point from which to make the change
      */
-    public mutating func lengthen(by chunk: TimeChunk, at anchor: Anchor) {
+    mutating func lengthen(by chunk: TimeChunk, at anchor: Anchor) {
         switch anchor {
         case .beginning:
             self.end = self.end?.add(chunk)
@@ -429,7 +429,7 @@ public extension TimePeriodProtocol {
      * - parameter timeInterval: The time interval to shorten the period by
      * - parameter anchor: The anchor point from which to make the change
      */
-    public mutating func shorten(by timeInterval: TimeInterval, at anchor: Anchor) {
+    mutating func shorten(by timeInterval: TimeInterval, at anchor: Anchor) {
         switch anchor {
         case .beginning:
             self.end = self.end?.addingTimeInterval(-timeInterval)
@@ -450,7 +450,7 @@ public extension TimePeriodProtocol {
      * - parameter chunk: The time chunk to shorten the period by
      * - parameter anchor: The anchor point from which to make the change
      */
-    public mutating func shorten(by chunk: TimeChunk, at anchor: Anchor) {
+    mutating func shorten(by chunk: TimeChunk, at anchor: Anchor) {
         switch anchor {
         case .beginning:
             self.end = self.end?.subtract(chunk)


### PR DESCRIPTION
Xcode 10.2 beta complains about redundant visibility keywords in extensions. Since we have warnings as errors turned on, I've gone ahead and removed `public` from all of the enclosed extensions.