### PR TITLE
Turn unmodified vars into lets

### DIFF
--- a/DateToolsSwift/DateTools/Date+Comparators.swift
+++ b/DateToolsSwift/DateTools/Date+Comparators.swift
@@ -44,7 +44,7 @@ public extension Date {
      *  - returns: A TimeChunk representing the time between the dates, in natural form
      */
     func chunkBetween(date: Date) -> TimeChunk {
-        var compenentsBetween = Calendar.autoupdatingCurrent.dateComponents([.year, .month, .day, .hour, .minute, .second], from: self, to: date)
+        let compenentsBetween = Calendar.autoupdatingCurrent.dateComponents([.year, .month, .day, .hour, .minute, .second], from: self, to: date)
         return TimeChunk(seconds: compenentsBetween.second!, minutes: compenentsBetween.minute!, hours: compenentsBetween.hour!, days: compenentsBetween.day!, weeks: 0, months: compenentsBetween.month!, years: compenentsBetween.year!)
         // TimeChunk(seconds: secondDelta, minutes: minuteDelta, hours: hourDelta, days: dayDelta, weeks: 0, months: monthDelta, years: yearDelta)
     }

--- a/DateToolsSwift/DateTools/TimePeriodGroup.swift
+++ b/DateToolsSwift/DateTools/TimePeriodGroup.swift
@@ -120,7 +120,7 @@ open class TimePeriodGroup: Sequence {
             return false // No need to sorting if they already have different counts
         }
         
-        var compArray1: [TimePeriodProtocol] = array1.sorted { (period1: TimePeriodProtocol, period2: TimePeriodProtocol) -> Bool in
+        let compArray1: [TimePeriodProtocol] = array1.sorted { (period1: TimePeriodProtocol, period2: TimePeriodProtocol) -> Bool in
             if period1.beginning == nil && period2.beginning == nil {
                 return false
             } else if (period1.beginning == nil) {
@@ -131,7 +131,7 @@ open class TimePeriodGroup: Sequence {
                 return period2.beginning! < period1.beginning!
             }
         }
-        var compArray2: [TimePeriodProtocol] = array2.sorted { (period1: TimePeriodProtocol, period2: TimePeriodProtocol) -> Bool in
+        let compArray2: [TimePeriodProtocol] = array2.sorted { (period1: TimePeriodProtocol, period2: TimePeriodProtocol) -> Bool in
             if period1.beginning == nil && period2.beginning == nil {
                 return false
             } else if (period1.beginning == nil) {


### PR DESCRIPTION
The Swift 5.1 compiler is stricter about using unmodified `var`s. There are three places in DateTools where this happens - changed them all to use immutable lets.